### PR TITLE
Using --prefer-lowest option instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
     - php: 5.4
       env:
         - LEGACY=true
-        - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+        - COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.5
       env: LEGACY=true
     - php: 5.6
@@ -25,7 +25,7 @@ jobs:
 before_script:
   - if [[ $LEGACY == 'true' ]]; then
       travis_retry composer remove phpunit/phpunit --dev;
-      travis_retry composer require phpunit/phpunit:^4 --dev;
+      travis_retry composer require phpunit/phpunit:^4.8.36 --dev;
       ./legacy.sh;
     fi
   - travis_retry composer self-update

--- a/legacy.sh
+++ b/legacy.sh
@@ -1,25 +1,21 @@
 #!/bin/sh
 
 # Convert to legacy version (Mac OS)
-#find tests -name '*.php' -exec sed -i '.bak' 's/PHPUnit\\Framework\\TestCase/PHPUnit_Framework_TestCase/' {} \;
 #find tests -name '*.php' -exec sed -i '.bak' 's/protected function setUp(): void/public function setUp()/' {} \;
 #find tests -name '*.php' -exec sed -i '.bak' 's/assertStringNotContainsString(/assertNotContains(/' {} \;
 #find tests -name '*.php' -exec sed -i '.bak' 's/assertStringContainsString(/assertContains(/' {} \;
 
 # Convert to legacy version (Linux)
-find tests -name '*.php' -exec sed -i 's/PHPUnit\\Framework\\TestCase/PHPUnit_Framework_TestCase/' {} \;
 find tests -name '*.php' -exec sed -i 's/protected function setUp(): void/public function setUp()/' {} \;
 find tests -name '*.php' -exec sed -i 's/assertStringNotContainsString(/assertNotContains(/' {} \;
 find tests -name '*.php' -exec sed -i 's/assertStringContainsString(/assertContains(/' {} \;
 
 # Convert to latest version (Mac OS)
-#find tests -name '*.php' -exec sed -i '.bak' 's/PHPUnit_Framework_TestCase/PHPUnit\\Framework\\TestCase/' {} \;
 #find tests -name '*.php' -exec sed -i '.bak' 's/public function setUp()/protected function setUp(): void/' {} \;
 #find tests -name '*.php' -exec sed -i '.bak' 's/assertNotContains(/assertStringNotContainsString(/' {} \;
 #find tests -name '*.php' -exec sed -i '.bak' 's/assertContains(/assertStringContainsString(/' {} \;
 
 # Convert to latest version (Linux)
-#find tests -name '*.php' -exec sed -i 's/PHPUnit_Framework_TestCase/PHPUnit\\Framework\\TestCase/' {} \;
 #find tests -name '*.php' -exec sed -i 's/public function setUp()/protected function setUp(): void/' {} \;
 #find tests -name '*.php' -exec sed -i 's/assertNotContains(/assertStringNotContainsString(/' {} \;
 #find tests -name '*.php' -exec sed -i 's/assertContains(/assertStringContainsString(/' {} \;

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Tamtamchik\SimpleFlash\Exceptions\FlashTemplateNotFoundException;
 use Tamtamchik\SimpleFlash\Flash;
 use Tamtamchik\SimpleFlash\TemplateFactory;
@@ -8,7 +9,7 @@ use Tamtamchik\SimpleFlash\Templates;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once 'BadTemplate.php';
 
-class FactoryTest extends PHPUnit\Framework\TestCase
+class FactoryTest extends TestCase
 {
     private $templates = [];
 

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Tamtamchik\SimpleFlash\Exceptions\FlashSingletonException;
 use Tamtamchik\SimpleFlash\Exceptions\FlashTemplateException;
 use Tamtamchik\SimpleFlash\Exceptions\FlashTemplateNotFoundException;
@@ -12,7 +13,7 @@ session_start();
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once 'BadTemplate.php';
 
-class FlashTest extends PHPUnit\Framework\TestCase
+class FlashTest extends TestCase
 {
     /** @test */
     public function testStaticCall()


### PR DESCRIPTION
# Changed log
- The `--prefer-stable` option has been defined on `composer.json` file.
I think it's fine to be removed.
- The `PHPUnit` version can define `^4.8.36` and it can be compatible with `PHPUnit\Framework\TestCase` namespace. And it can remove snippets about replacing `PHPUnit` class namespace.