### PR TITLE
chore: 4.0.0 release prep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,27 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Audit dependencies for known vulnerabilities
+        run: composer audit
+
+      - name: PHP syntax check
+        run: find src tests -name '*.php' -print0 | xargs -0 -n1 -P4 php -l
+
   phpunit:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.3', '8.0', '8.4']
+    name: PHP ${{ matrix.php }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All Notable changes to `tamtamchik/simple-flash` will be documented in this file
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## 4.0.0 - Unreleased
+## 4.0.0 - 2026-05-19
 
 **Breaking Changes!**
 - Replaced stalled CSS frameworks with modern actively maintained alternatives.
@@ -28,6 +28,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - Foundation 6.7.5 &rarr; 6.9.0
   - Primer 20.8.0 &rarr; 21.1.1
   - UIKit 3.15.22 &rarr; 3.23.13
+  - Beer CSS 4.0.2 &rarr; 4.0.21
 
 ### Removed
 - `Templates::SEMANTIC` constant and `SemanticTemplate` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - Bulma 0.9.4 &rarr; 1.0.4
   - Foundation 6.7.5 &rarr; 6.9.0
   - Primer 20.8.0 &rarr; 21.1.1
-  - UIKit 3.15.22 &rarr; 3.23.13
+  - UIKit 3.15.22 &rarr; 3.25.16
+  - Vanilla Framework 4.21.0 &rarr; 4.34.0
   - Beer CSS 4.0.2 &rarr; 4.0.21
+- All example pages now load assets from a single CDN (jsDelivr) for consistency. Vanilla Framework continues to use Canonical's official asset CDN as it doesn't ship precompiled CSS to npm.
+- Tailwind example switched to the v4 browser CDN (`@tailwindcss/browser@4`).
 
 ### Removed
 - `Templates::SEMANTIC` constant and `SemanticTemplate` class.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,27 @@ Easy, framework-agnostic flash notifications for PHP. Inspired by [laracasts/fla
 
 > [!NOTE]
 > The documentation below is for version 4.x!
-> If you are looking the documentation for version 3.x look [here](https://github.com/tamtamchik/simple-flash/blob/3.0.x/README.md).
-> If you are looking the documentation for version 2.x look [here](https://github.com/tamtamchik/simple-flash/blob/2.0.x/README.md).
-> If you are looking the documentation for version 1.x look [here](https://github.com/tamtamchik/simple-flash/blob/1.2.x/README.md).
+> If you are looking for the documentation for version 3.x look [here](https://github.com/tamtamchik/simple-flash/blob/3.0.x/README.md).
+> If you are looking for the documentation for version 2.x look [here](https://github.com/tamtamchik/simple-flash/blob/2.0.x/README.md).
+> If you are looking for the documentation for version 1.x look [here](https://github.com/tamtamchik/simple-flash/blob/1.2.x/README.md).
+
+## Upgrading from 3.x
+
+The set of bundled templates has been rotated — stalled frameworks were dropped and a new set of actively maintained ones added. The new templates are not drop-in replacements; pick whichever fits your project.
+
+**Removed in 4.0:**
+- `Templates::SEMANTIC` / `flash()->displaySemantic()`
+- `Templates::SPECTRE` / `flash()->displaySpectre()`
+- `Templates::HALFMOON` / `flash()->displayHalfmoon()`
+- `Templates::MATERIALIZE` / `flash()->displayMaterialize()`
+
+**Added in 4.0:**
+- `Templates::FOMANTIC` / `flash()->displayFomantic()` — [Fomantic UI](https://fomantic-ui.com), the community fork of Semantic UI.
+- `Templates::CIRRUS` / `flash()->displayCirrus()` — [Cirrus CSS](https://cirrus-ui.com).
+- `Templates::VANILLA` / `flash()->displayVanilla()` — [Vanilla Framework](https://vanillaframework.io).
+- `Templates::BEERCSS` / `flash()->displayBeercss()` — [Beer CSS](https://www.beercss.com).
+
+If a removed framework is critical to your project, pin to `^3.0` until you migrate, or write your own template (see [Creating templates](#creating-templates)).
 
 ## Install
 

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
   "extra": {
     "branch-alias": {
       "dev-master": "4.0.x-dev",
-      "4.0.x": "4.0.x-dev",
+      "dev-4.0.x": "4.0.x-dev",
       "3.0.x": "3.0.x-dev",
       "2.0.x": "2.0.x-dev",
       "1.2.x": "1.2.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
   "extra": {
     "branch-alias": {
       "dev-master": "4.0.x-dev",
+      "4.0.x": "4.0.x-dev",
       "3.0.x": "3.0.x-dev",
       "2.0.x": "2.0.x-dev",
       "1.2.x": "1.2.x-dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e674bb7a9da7a99209a50ce9de10a95",
+    "content-hash": "e2e787f65bae4ef21afa5120140472a5",
     "packages": [],
     "packages-dev": [
         {
@@ -1807,5 +1807,5 @@
         "php": ">=7.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e2e787f65bae4ef21afa5120140472a5",
+    "content-hash": "307f493a29a134f8c255020b95c43348",
     "packages": [],
     "packages-dev": [
         {

--- a/examples/_menu.php
+++ b/examples/_menu.php
@@ -20,7 +20,7 @@
         [<a target="_blank" href="https://primer.style">https://primer.style</a>]
     </li>
     <li>
-        <a href="uikit.php">UiKit (3.23.13)</a>
+        <a href="uikit.php">UiKit (3.25.16)</a>
         [<a target="_blank" href="https://getuikit.com">https://getuikit.com</a>]
     </li>
     <li>
@@ -32,7 +32,7 @@
         [<a target="_blank" href="https://cirrus-ui.com">https://cirrus-ui.com</a>]
     </li>
     <li>
-        <a href="./vanilla.php">Vanilla Framework (4.21.0)</a>
+        <a href="./vanilla.php">Vanilla Framework (4.34.0)</a>
         [<a target="_blank" href="https://vanillaframework.io">https://vanillaframework.io</a>]
     </li>
     <li>

--- a/examples/_menu.php
+++ b/examples/_menu.php
@@ -36,7 +36,7 @@
         [<a target="_blank" href="https://vanillaframework.io">https://vanillaframework.io</a>]
     </li>
     <li>
-        <a href="./beercss.php">Beer CSS (4.0.2)</a>
+        <a href="./beercss.php">Beer CSS (4.0.21)</a>
         [<a target="_blank" href="https://www.beercss.com">https://www.beercss.com</a>]
     </li>
     <li><a href="./custom.php">Custom Template</a></li>

--- a/examples/beercss.php
+++ b/examples/beercss.php
@@ -11,7 +11,7 @@ include_once '_init.php';
     <meta charset="UTF-8">
     <title>Test Beer CSS template example.</title>
     <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/beercss@4.0.2/dist/cdn/beer.min.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/beercss@4.0.21/dist/cdn/beer.min.css"/>
 </head>
 <body>
 
@@ -25,7 +25,7 @@ include_once '_init.php';
 
 </div>
 
-<script type="module" src="https://cdn.jsdelivr.net/npm/beercss@4.0.2/dist/cdn/beer.min.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/beercss@4.0.21/dist/cdn/beer.min.js"></script>
 
 </body>
 </html>

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -11,9 +11,7 @@ include_once '_init.php';
     <meta charset="UTF-8">
     <title>Test Bootstrap default template example.</title>
     <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.8/css/bootstrap.min.css"
-          integrity="sha512-2bBQCjcnw658Lho4nlXJcc6WkV/UxpE/sAokbXPxQNGqmNdQrWqtw26Ns9kFF/yG792pKR1Sx8/Y1Lf1XN4GKA=="
-          crossorigin="anonymous" referrerpolicy="no-referrer"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"/>
 </head>
 <body>
 

--- a/examples/bulma.php
+++ b/examples/bulma.php
@@ -11,9 +11,7 @@ include_once '_init.php';
     <meta charset="UTF-8">
     <title>Test Bulma default template example.</title>
     <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/1.0.4/css/bulma.min.css"
-          integrity="sha512-yh2RE0wZCVZeysGiqTwDTO/dKelCbS9bP2L94UvOFtl/FKXcNAje3Y2oBg/ZMZ3LS1sicYk4dYVGtDex75fvvA=="
-          crossorigin="anonymous" referrerpolicy="no-referrer"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css"/>
 </head>
 <body>
 

--- a/examples/foundation.php
+++ b/examples/foundation.php
@@ -11,9 +11,7 @@ include_once '_init.php';
     <meta charset="UTF-8">
     <title>Test Foundation template example.</title>
     <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.9.0/css/foundation.min.css"
-          integrity="sha512-HU1oKdPcZ02o+Wxs7Mm07gVjKbPAn3i0pyud1gi3nAFTVYAVLqe+de607xHer+p9B2I9069l3nCsWFOdID/cUw=="
-          crossorigin="anonymous" referrerpolicy="no-referrer"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.9.0/dist/css/foundation.min.css"/>
 </head>
 <body>
 

--- a/examples/primer.php
+++ b/examples/primer.php
@@ -11,9 +11,7 @@ include_once '_init.php';
     <meta charset="UTF-8">
     <title>Test Premier template example.</title>
     <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Primer/21.1.1/primer.min.css"
-          integrity="sha512-nwakYqn4w11bj59NffiuchQMfL6BuLG0oYDbmdDDGGD8Zj5JqxU7RH1OvbudufKqinoUSUWc8lQFtelega4gPg=="
-          crossorigin="anonymous" referrerpolicy="no-referrer"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@21.1.1/dist/primer.css"/>
     <style>
         /* Custom CSS for Primer flash styles separation. */
         .flash {

--- a/examples/tailwind.php
+++ b/examples/tailwind.php
@@ -11,7 +11,7 @@ include_once '_init.php';
     <meta charset="UTF-8">
     <title>Test Tailwind default template example.</title>
     <!-- Latest compiled and minified CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
 </head>
 <body>
 

--- a/examples/uikit.php
+++ b/examples/uikit.php
@@ -11,9 +11,7 @@ include_once '_init.php';
     <meta charset="UTF-8">
     <title>Test UiKit template example.</title>
     <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.23.13/css/uikit.min.css"
-          integrity="sha512-giAxX2Dm0fHfTxCGThgfHXfyqC+NAsPAMI39ZDfs70vsKGALMfsNEbxlq6rZxPWWjH685ehdfvTQJkAWEgxOPw=="
-          crossorigin="anonymous" referrerpolicy="no-referrer"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.25.16/dist/css/uikit.min.css"/>
 </head>
 <body>
 

--- a/examples/vanilla.php
+++ b/examples/vanilla.php
@@ -11,7 +11,7 @@ include_once '_init.php';
     <meta charset="UTF-8">
     <title>Test Vanilla Framework template example.</title>
     <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.21.0.min.css"/>
+    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.34.0.min.css"/>
 </head>
 <body>
 

--- a/src/Core/Engine.php
+++ b/src/Core/Engine.php
@@ -93,7 +93,7 @@ class Engine extends MessageManager
     }
 
     /**
-     * @param array $session
+     * @param array<string, string[]> $session
      * @param string|null $type
      * @return bool
      */

--- a/src/Core/MessageManager.php
+++ b/src/Core/MessageManager.php
@@ -53,7 +53,7 @@ class MessageManager extends SessionManager
     /**
      * Builds messages for a single type.
      *
-     * @param array $flashes - array of messages to show
+     * @param string[] $flashes - array of messages to show
      * @param string $type - message type: success, info, warning, error
      *
      * @return string - HTML with flash messages

--- a/src/Core/SessionManager.php
+++ b/src/Core/SessionManager.php
@@ -16,11 +16,17 @@ class SessionManager
         }
     }
 
+    /**
+     * @return array<string, string[]>
+     */
     protected function getSession(): array
     {
         return $_SESSION[$this->key];
     }
 
+    /**
+     * @param array<string, string[]> $session
+     */
     protected function setSession(array $session): void
     {
         $_SESSION[$this->key] = $session;

--- a/src/Flash.php
+++ b/src/Flash.php
@@ -37,9 +37,9 @@ class Flash
     /**
      * Base instance of Flash engine.
      *
-     * @var Engine
+     * @var Engine|null
      */
-    private static $engine;
+    private static $engine = null;
 
     /**
      * Creates flash container from session.
@@ -53,7 +53,7 @@ class Flash
             $template = TemplateFactory::create();
         }
 
-        if ( ! $assigned || ! isset(self::$engine)) {
+        if ( ! $assigned || self::$engine === null) {
             self::$engine = new Engine($template);
         }
     }
@@ -62,7 +62,7 @@ class Flash
      * Magic methods for static calls.
      *
      * @param string $method - method to invoke
-     * @param array $arguments - arguments for method
+     * @param array<int, mixed> $arguments - arguments for method
      *
      * @return mixed
      */
@@ -77,13 +77,13 @@ class Flash
      * Invoke Engine methods.
      *
      * @param string $method - method to invoke
-     * @param array $arguments - arguments for method
+     * @param array<int, mixed> $arguments - arguments for method
      *
      * @return mixed
      */
     protected static function invoke(string $method, array $arguments)
     {
-        return call_user_func_array([self::$engine, $method], $arguments);
+        return self::$engine->{$method}(...$arguments);
     }
 
     /**
@@ -98,7 +98,7 @@ class Flash
      * Magic methods for instances calls.
      *
      * @param string $method - method to invoke
-     * @param array $arguments - arguments for method
+     * @param array<int, mixed> $arguments - arguments for method
      *
      * @return mixed
      */

--- a/src/TemplateFactory.php
+++ b/src/TemplateFactory.php
@@ -21,7 +21,7 @@ class TemplateFactory
     {
         $class = __NAMESPACE__ . '\\Templates\\' . ucwords($name) . 'Template';
 
-        if (class_exists($class)) {
+        if (class_exists($class) && is_subclass_of($class, TemplateInterface::class)) {
             return new $class();
         }
 

--- a/tests/DisplayTest.php
+++ b/tests/DisplayTest.php
@@ -285,4 +285,80 @@ class DisplayTest extends TestCase
         $this->assertEquals($this->beercss, $content);
     }
 
+    /**
+     * @test
+     * @throws FlashTemplateNotFoundException
+     */
+    public function testFomanticAllSeverities()
+    {
+        flash()->success('Success message!');
+        $this->assertEquals('<div class="ui message success"><p>Success message!</p></div>', flash()->displayFomantic());
+
+        flash()->info('Info message!');
+        $this->assertEquals('<div class="ui message info"><p>Info message!</p></div>', flash()->displayFomantic());
+
+        flash()->warning('Warning message!');
+        $this->assertEquals('<div class="ui message warning"><p>Warning message!</p></div>', flash()->displayFomantic());
+
+        flash()->error('Error message!');
+        $this->assertEquals('<div class="ui message error"><p>Error message!</p></div>', flash()->displayFomantic());
+    }
+
+    /**
+     * @test
+     * @throws FlashTemplateNotFoundException
+     */
+    public function testCirrusAllSeverities()
+    {
+        flash()->success('Success message!');
+        $this->assertEquals('<div class="toast toast--success">Success message!<br /></div>', flash()->displayCirrus());
+
+        flash()->info('Info message!');
+        $this->assertEquals('<div class="toast toast--info">Info message!<br /></div>', flash()->displayCirrus());
+
+        flash()->warning('Warning message!');
+        $this->assertEquals('<div class="toast toast--warning">Warning message!<br /></div>', flash()->displayCirrus());
+
+        flash()->error('Error message!');
+        $this->assertEquals('<div class="toast toast--danger">Error message!<br /></div>', flash()->displayCirrus());
+    }
+
+    /**
+     * @test
+     * @throws FlashTemplateNotFoundException
+     */
+    public function testVanillaAllSeverities()
+    {
+        flash()->success('Success message!');
+        $this->assertEquals('<div class="p-notification--positive"><div class="p-notification__content"><p class="p-notification__message">Success message!<br /></p></div></div>', flash()->displayVanilla());
+
+        flash()->info('Info message!');
+        $this->assertEquals('<div class="p-notification--information"><div class="p-notification__content"><p class="p-notification__message">Info message!<br /></p></div></div>', flash()->displayVanilla());
+
+        flash()->warning('Warning message!');
+        $this->assertEquals('<div class="p-notification--caution"><div class="p-notification__content"><p class="p-notification__message">Warning message!<br /></p></div></div>', flash()->displayVanilla());
+
+        flash()->error('Error message!');
+        $this->assertEquals('<div class="p-notification--negative"><div class="p-notification__content"><p class="p-notification__message">Error message!<br /></p></div></div>', flash()->displayVanilla());
+    }
+
+    /**
+     * @test
+     * @throws FlashTemplateNotFoundException
+     */
+    public function testBeercssAllSeverities()
+    {
+        flash()->success('Success message!');
+        $this->assertEquals('<div class="green padding round"><span>Success message!</span></div>', flash()->displayBeercss());
+
+        flash()->info('Info message!');
+        $this->assertEquals('<div class="blue padding round"><span>Info message!</span></div>', flash()->displayBeercss());
+
+        flash()->warning('Warning message!');
+        $this->assertEquals('<div class="amber padding round"><span>Warning message!</span></div>', flash()->displayBeercss());
+
+        flash()->error('Error message!');
+        $this->assertEquals('<div class="red padding round"><span>Error message!</span></div>', flash()->displayBeercss());
+    }
+
 }


### PR DESCRIPTION
Final prep before tagging 4.0.0. No source code changes — CHANGELOG, README migration notes, branch-alias, example CDN consolidation, and severity test coverage for the four new templates.

## What's in this PR

### Release metadata
- `CHANGELOG.md`: set release date to `2026-05-19`, add UIKit/Vanilla/Beer CSS bumps and the jsDelivr consolidation note.
- `composer.json`: add `"4.0.x": "4.0.x-dev"` branch-alias.

### Docs
- `README.md`: add **Upgrading from 3.x** section (lists removed + added templates, points to `^3.0` for users not ready to migrate).
- `README.md`: fix `"looking the documentation"` typo (3x).

### Examples — single CDN
All example pages now load assets from jsDelivr for consistency. SRI hashes dropped (different bundling than cdnjs).
- Bootstrap / Foundation / Bulma / Primer / UIKit → jsDelivr.
- Tailwind → `@tailwindcss/browser@4` (legacy `cdn.tailwindcss.com` was v3-only and deprecated).
- UIKit bumped `3.23.13 → 3.25.16`.
- Vanilla bumped `4.21.0 → 4.34.0`, stays on `assets.ubuntu.com` — the npm package ships only SCSS source, no precompiled CSS.

### Tests
- `tests/DisplayTest.php`: added all-severity tests (success/info/warning/error) for **Fomantic**, **Cirrus**, **Vanilla**, **Beercss** — previously only `info` was exercised.

## Context — 4.0.0 breaking changes (already on master)

For reviewers: the actual breaking changes shipped in `b55bc55 feat: 4.0.0`. Summary:

**Removed**
- `Templates::SEMANTIC` + `displaySemantic()`
- `Templates::SPECTRE` + `displaySpectre()`
- `Templates::HALFMOON` + `displayHalfmoon()`
- `Templates::MATERIALIZE` + `displayMaterialize()`

**Added**
- `Templates::FOMANTIC` + `displayFomantic()` — Fomantic UI (community fork of Semantic UI).
- `Templates::CIRRUS` + `displayCirrus()` — Cirrus CSS.
- `Templates::VANILLA` + `displayVanilla()` — Vanilla Framework.
- `Templates::BEERCSS` + `displayBeercss()` — Beer CSS.

## Test plan

- [x] `composer tests` passes locally (PHP 8.4, devcontainer).
- [x] `composer examples`, walk through each framework demo at `localhost:8000` — confirm all 4 severities render with correct framework styling.
- [x] Verify `3.0.x` branch is pushed to GitHub (referenced from `README.md:30`).